### PR TITLE
fix recursive import in registry.py

### DIFF
--- a/xanesnet/registry.py
+++ b/xanesnet/registry.py
@@ -13,17 +13,11 @@ PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 this program.  If not, see <https://www.gnu.org/licenses/>.
 """
-from xanesnet.scheme import *
 
 DATASET_REGISTRY = {}
 MODEL_REGISTRY = {}
 DESCRIPTOR_REGISTRY = {}
-SCHEME_REGISTRY = {
-    "nn": {"learn": NNLearn, "predict": NNPredict, "eval": NNEval},
-    "ae": {"learn": AELearn, "predict": AEPredict, "eval": AEEval},
-    "aegan": {"learn": AEGANLearn, "predict": AEGANPredict, "eval": AEGANEval},
-    "gnn": {"learn": GNNLearn, "predict": GNNPredict, "eval": None},
-}
+SCHEME_REGISTRY = {}
 LEARN_SCHEME_REGISTRY = {}
 PREDICT_SCHEME_REGISTRY = {}
 EVAL_SCHEME_REGISTRY = {}
@@ -73,6 +67,46 @@ def register_descriptor(name):
 
 def register_scheme(model_name, scheme_name):
     def decorator(cls):
+        if not SCHEME_REGISTRY:
+            from xanesnet.scheme import (
+                AEEval,
+                AEGANEval,
+                AEGANLearn,
+                AEGANPredict,
+                AELearn,
+                AEPredict,
+                GNNLearn,
+                GNNPredict,
+                NNEval,
+                NNLearn,
+                NNPredict,
+            )
+
+            SCHEME_REGISTRY.update(
+                {
+                    "nn": {
+                        "learn": NNLearn,
+                        "predict": NNPredict,
+                        "eval": NNEval,
+                    },
+                    "ae": {
+                        "learn": AELearn,
+                        "predict": AEPredict,
+                        "eval": AEEval,
+                    },
+                    "aegan": {
+                        "learn": AEGANLearn,
+                        "predict": AEGANPredict,
+                        "eval": AEGANEval,
+                    },
+                    "gnn": {
+                        "learn": GNNLearn,
+                        "predict": GNNPredict,
+                        "eval": None,
+                    },
+                },
+            )
+
         scheme = SCHEME_REGISTRY.get(scheme_name)
         if scheme is None:
             raise ValueError(f"Scheme '{scheme_name}' is not registered.")


### PR DESCRIPTION
fixes a recursive import of `scheme` which gave me the below traceback. we import later (and only once), after the module has been entirely initialized, to avoid the circular import.
```
Traceback (most recent call last):
  File "/home/<user>/.local/src/xanesnet/xanesnet/registry.py", line 16, in <module>
    from xanesnet.scheme import *
  File "/home/<user>/.local/src/xanesnet/xanesnet/scheme/__init__.py", line 1, in <module>
    from .nn_learn import NNLearn
  File "/home/<user>/.local/src/xanesnet/xanesnet/scheme/nn_learn.py", line 25, in <module>
    from xanesnet.scheme.base_learn import Learn
  File "/home/<user>/.local/src/xanesnet/xanesnet/scheme/base_learn.py", line 34, in <module>
    from xanesnet.utils.switch import (
  File "/home/<user>/.local/src/xanesnet/xanesnet/utils/__init__.py", line 5, in <module>
    from . import plot
  File "/home/<user>/.local/src/xanesnet/xanesnet/utils/plot.py", line 26, in <module>
    from xanesnet.utils.io import save_xanes, mkdir_output
  File "/home/<user>/.local/src/xanesnet/xanesnet/utils/io.py", line 36, in <module>
    from xanesnet.models.pre_trained import ModelInfo
  File "/home/<user>/.local/src/xanesnet/xanesnet/models/__init__.py", line 10, in <module>
    from .gnn import GNN
  File "/home/<user>/.local/src/xanesnet/xanesnet/models/gnn.py", line 25, in <module>
    from xanesnet.registry import register_model, register_scheme
ImportError: cannot import name 'register_model' from partially initialized module 'xanesnet.registry' (most likely due to a circular import) (/home/<user>/.local/src/xanesnet/xanesnet/registry.py)
```